### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 on: push
 name: 🚀 Deploy website on push
+permissions:
+  contents: read
 jobs:
   web-deploy:
     name: 🎉 Deploy


### PR DESCRIPTION
Potential fix for [https://github.com/piotcharis/charalampos-piotopoulos/security/code-scanning/1](https://github.com/piotcharis/charalampos-piotopoulos/security/code-scanning/1)

In general, to fix this issue you add an explicit `permissions` block either at the workflow root (applies to all jobs) or within the specific job. You set the minimal set of scopes required for the tasks in the workflow, typically starting from `contents: read` and adding additional granular permissions only if some step needs them.

For this specific workflow, the job only checks out code (`actions/checkout`), sets up Node, builds, lists files, and deploys via FTP to an external server. None of these require write access to the repository via `GITHUB_TOKEN`. The minimal safe change is to add `permissions: contents: read` at the workflow root (or within `web-deploy`). Adding it at the top level keeps the YAML succinct, and there is only one job here. Concretely, in `.github/workflows/deploy.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: 🚀 Deploy website on push` and `jobs:` lines. No imports or additional definitions are needed, as this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
